### PR TITLE
fix: iOS app name

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>IRL Link</string>
+	<string>irllink</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -6,6 +6,8 @@
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>IRL Link</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,13 +15,15 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>irllink</string>
+	<string>IRL Link</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleSpokenName</key>
+	<string>IRL Link</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This changes the app name to match how it is in the Play Store.
Before
<img width="75" alt="Screenshot 2023-04-03 at 12 55 19" src="https://user-images.githubusercontent.com/100245448/229613616-0a00b95e-401c-436d-83ab-7dd1eb5713ab.png">
After
<img width="80" alt="Screenshot 2023-04-03 at 12 54 09" src="https://user-images.githubusercontent.com/100245448/229613643-91d8e8fe-c490-44e2-ac62-b2d38b3c5867.png">
