### PR TITLE
fix: ci tweaks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,31 +7,37 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    branches:
+      - master
+  release:
+    types: [released]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
-
       - name: Test connection
         run: curl "https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json"
       
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
       
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v4
         with:
-          java-version: '17.x'
+          distribution: "zulu"
+          java-version: "17"
           
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
         
-      - run: flutter pub get
-      - name: Analyze project source
-        run: dart analyze
-      - run: flutter build apk --debug
-      - run: flutter build appbundle --debug
+     - working-directory: ${{ inputs.working-directory }}
+        run: |
+          flutter pub get
+          dart analyze
+          flutter build apk --debug
+          flutter build appbundle --debug

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ IRL Link is a mobile application to monitor your IRL Stream.
 [![GitHub](https://img.shields.io/github/license/lezdcs/irl_link?color=%238442f5)](https://choosealicense.com/licenses/gpl-3.0/)
 
 ## Download
-<a href='https://play.google.com/store/apps/details?id=dev.lezd.www.irllink&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' height="85" src='./assets/google-play-badge.png'/></a>
-<a href="https://apps.apple.com/app/id6447156883"><img alt='Download on the App Store' height="85" src="./assets/apple-download.svg"></a>
+<a href='https://play.google.com/store/apps/details?id=dev.lezd.www.irllink&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'><img alt='Get it on Google Play' height="85" src='./lib/assets/google-play-badge.png'/></a>
+<a href="https://apps.apple.com/app/id6447156883"><img alt='Download on the App Store' height="85" src="./lib/assets/apple-download.svg"></a>
 
 Also available in the [Releases](https://github.com/LezdCS/irl_link/releases).
 <br />


### PR DESCRIPTION
This is an attempt at making the ci run faster for development, I removed making the CI builds when pushing PRs only when it goes to the master branch will it run. Ideally we should support downloading the apk files of every version as well as the aab maybe after the fact the ipa